### PR TITLE
specify that interval is an int argument

### DIFF
--- a/envoystat/envoystat.py
+++ b/envoystat/envoystat.py
@@ -24,7 +24,7 @@ def main(args):
     signal.signal(signal.SIGINT, signal_handler)
 
     print datetime.datetime.now().strftime('%Y/%m/%d'), request(args['admin'], '/server_info').read()
-    
+
     header = args['fields']
     formatter = ' '.join('{: >10}' for i in range(len(header)))
     ts = lambda: datetime.datetime.now().strftime('%I:%M:%S %p')
@@ -93,7 +93,7 @@ if __name__ == '__main__':
     )
     parser.add_argument(
         '-i', '--interval', default=1,
-        help="Interval in seconds",
+        type=int, help="Interval in seconds",
     )
     parser.add_argument(
         '-f', '--fields',


### PR DESCRIPTION
Without this fix I was getting the following error on both Python 2 and 3:
```
➜  envoy-tools git:(dereka/py3) ✗ python envoystat/envoystat.py -a http://localhost:9901 -p http.ingress_http.downstream_ -i 1 -f rq_2xx rq_5xx
2018/08/01 envoy 0/1.8.0-dev//DEBUG live 324 324 0

07:56:48 PM     rq_2xx     rq_5xx
Traceback (most recent call last):
  File "envoystat/envoystat.py", line 113, in <module>
    main(vars(parser.parse_args()))
  File "envoystat/envoystat.py", line 65, in main
    next_loop_delay = args['interval'] - (time.time() - loop_start)
TypeError: unsupported operand type(s) for -: 'str' and 'float'
```

Signed-off-by: Derek Argueta <dereka@pinterest.com>