### PR TITLE
csds client: add minor support to FindMessageByURL()

### DIFF
--- a/csds-client/client/util/util.go
+++ b/csds-client/client/util/util.go
@@ -21,10 +21,14 @@ import (
 	envoy_api_v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	envoy_config_cluster_v3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	envoy_config_endpoint_v3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
+	envoy_config_filter_http_cors_v2 "github.com/envoyproxy/go-control-plane/envoy/config/filter/http/cors/v2"
+	envoy_config_filter_http_fault_v2 "github.com/envoyproxy/go-control-plane/envoy/config/filter/http/fault/v2"
 	envoy_config_filter_http_router_v2 "github.com/envoyproxy/go-control-plane/envoy/config/filter/http/router/v2"
 	envoy_config_filter_network_http_connection_manager_v2 "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
 	envoy_config_listener_v3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	envoy_config_route_v3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	envoy_extensions_filters_http_cors_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/cors/v3"
+	envoy_extensions_filters_http_fault_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/fault/v3"
 	envoy_extensions_filters_http_router_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/router/v3"
 	envoy_extensions_filters_network_http_connection_manager_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	"github.com/ghodss/yaml"
@@ -98,6 +102,18 @@ func (r *TypeResolver) FindMessageByURL(url string) (protoreflect.MessageType, e
 	case "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment":
 		clusterLoadAssignment := envoy_config_endpoint_v3.ClusterLoadAssignment{}
 		return clusterLoadAssignment.ProtoReflect().Type(), nil
+	case "type.googleapis.com/envoy.config.filter.http.fault.v2.HTTPFault":
+		httpFault := envoy_config_filter_http_fault_v2.HTTPFault{}
+		return httpFault.ProtoReflect().Type(), nil
+	case "type.googleapis.com/envoy.extensions.filters.http.fault.v3.HTTPFault":
+		httpFault := envoy_extensions_filters_http_fault_v3.HTTPFault{}
+		return httpFault.ProtoReflect().Type(), nil
+	case "type.googleapis.com/envoy.config.filter.http.cors.v2.Cors":
+		cors := envoy_config_filter_http_cors_v2.Cors{}
+		return cors.ProtoReflect().Type(), nil
+	case "type.googleapis.com/envoy.extensions.filters.http.cors.v3.Cors":
+		cors := envoy_extensions_filters_http_cors_v3.Cors{}
+		return cors.ProtoReflect().Type(), nil
 	default:
 		return nil, protoregistry.NotFound
 	}


### PR DESCRIPTION
This PR includes adding several message types support to `FindMessageByURL()` 
- `"type.googleapis.com/envoy.config.filter.http.fault.v2.HTTPFault"`
- `"type.googleapis.com/envoy.extensions.filters.http.fault.v3.HTTPFault"`
- `"type.googleapis.com/envoy.config.filter.http.cors.v2.Cors"`
- `"type.googleapis.com/envoy.extensions.filters.http.cors.v3.Cors"`

Signed-off-by: Yutong Li <yli59322@usc.edu>
/cc @fuqianggao