### PR TITLE
feature: adds support for go-control-plane based xDS implementations

### DIFF
--- a/csds-client/README.md
+++ b/csds-client/README.md
@@ -1,7 +1,10 @@
 # CSDS Client
 [Client status discovery service (CSDS)](https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/status/v3/csds.proto) is a generic xDS API that can be used to get information about data plane clients from the control plane’s point of view. It is useful to enhance debuggability of the service mesh, where lots of xDS clients are connected to the control plane.<br/>
 The CSDS client is developed as a generic tool that can be used/extended to work with different xDS control planes.<br/>
-For now, this initial version of this CSDS client only supports GCP's [Traffic Director](https://cloud.google.com/traffic-director).
+For now, this initial version of this CSDS client only supports:
+* GCP's [Traffic Director](https://cloud.google.com/traffic-director).
+* Envoy's [go-control-plane](https://github.com/envoyproxy/go-control-plane) based implementations.
+
 <br/>Before you start, you'll need [Go](https://golang.org/) installed.
 
 # Building

--- a/csds-client/client/client.go
+++ b/csds-client/client/client.go
@@ -4,21 +4,32 @@ import (
 	"time"
 )
 
+// Platforms supported by client implementations
+// where `go` is an xDS implementation based on
+// https://github.com/envoyproxy/go-control-plane
+var (
+	SupportedPlatforms []string = []string{"gcp", "go"}
+)
+
 // ClientOptions are options that are common to use in all the version implementations of client
 // TODO: If ClientOptions will no longer be common to use in all the version, it will need to be
 //  implemented in version packages
 type ClientOptions struct {
-	Uri             string
-	Platform        string
-	AuthnMode       string
-	RequestFile     string
-	RequestYaml     string
-	Jwt             string
-	ConfigFile      string
-	MonitorInterval time.Duration
-	Visualization   bool
-	FilterMode      string
-	FilterPattern   string
+	Uri                   string
+	Authority             string
+	Platform              string
+	AuthnMode             string
+	RequestFile           string
+	RequestYaml           string
+	Jwt                   string
+	ConfigFile            string
+	MonitorInterval       time.Duration
+	Visualization         bool
+	FilterMode            string
+	FilterPattern         string
+	TLSCertFilepath       string
+	TLSPrivateKeyFilepath string
+	TLSCACertsFilepath    string
 }
 
 // Client implements CSDS Client of a particular version. Upon creation of the new client it is

--- a/csds-client/client/v2/client.go
+++ b/csds-client/client/v2/client.go
@@ -60,8 +60,9 @@ func (c *ClientV2) parseNodeMatcher() error {
 				return fmt.Errorf("missing field %v in NodeMatcher", key)
 			}
 		}
+	case "go":
 	default:
-		return fmt.Errorf("%s platform is not supported, list of supported platforms: gcp", c.opts.Platform)
+		return fmt.Errorf("%s platform is not supported. supported platforms: %v", c.opts.Platform, client.SupportedPlatforms)
 	}
 
 	if c.opts.FilterMode != "" && c.opts.FilterMode != "prefix" && c.opts.FilterMode != "suffix" && c.opts.FilterMode != "regex" {
@@ -99,6 +100,13 @@ func (c *ClientV2) connWithAuth() error {
 				return err
 			}
 			return nil
+		case "go":
+			dialOpts, err := clientutil.DialOptions(&c.opts)
+			if err != nil {
+				return fmt.Errorf("could not build gRPC client dial options: %v", err)
+			}
+			c.clientConn, err = grpc.Dial(c.opts.Uri, dialOpts...)
+			return err
 		default:
 			return errors.New("auto authentication mode for this platform is not supported. Please use jwt_file instead")
 		}

--- a/csds-client/client/v3/client.go
+++ b/csds-client/client/v3/client.go
@@ -60,8 +60,9 @@ func (c *ClientV3) parseNodeMatcher() error {
 				return fmt.Errorf("missing field %v in NodeMatcher", key)
 			}
 		}
+	case "go":
 	default:
-		return fmt.Errorf("%s platform is not supported, list of supported platforms: gcp", c.opts.Platform)
+		return fmt.Errorf("%s platform is not supported. supported platforms: %v", c.opts.Platform, client.SupportedPlatforms)
 	}
 
 	if c.opts.FilterMode != "" && c.opts.FilterMode != "prefix" && c.opts.FilterMode != "suffix" && c.opts.FilterMode != "regex" {
@@ -84,7 +85,7 @@ func (c *ClientV3) connWithAuth() error {
 			}
 			return nil
 		default:
-			return fmt.Errorf("%s platform is not supported, list of supported platforms: gcp", c.opts.Platform)
+			return fmt.Errorf("%s platform is not supported for jwt authentication, list of supported platforms: gcp", c.opts.Platform)
 		}
 
 	case "auto":
@@ -99,6 +100,13 @@ func (c *ClientV3) connWithAuth() error {
 				return err
 			}
 			return nil
+		case "go":
+			dialOpts, err := clientutil.DialOptions(&c.opts)
+			if err != nil {
+				return fmt.Errorf("could not build gRPC client dial options: %v", err)
+			}
+			c.clientConn, err = grpc.Dial(c.opts.Uri, dialOpts...)
+			return err
 		default:
 			return errors.New("auto authentication mode for this platform is not supported. Please use jwt_file instead")
 		}
@@ -112,8 +120,8 @@ func New(option client.ClientOptions) (*ClientV3, error) {
 	c := &ClientV3{
 		opts: option,
 	}
-	if c.opts.Platform != "gcp" {
-		return nil, fmt.Errorf("%s platform is not supported, list of supported platforms: gcp", c.opts.Platform)
+	if c.opts.Platform != "gcp" && c.opts.Platform != "go" {
+		return nil, fmt.Errorf("%s platform is not supported, list of supported platforms: [gcp, go]", c.opts.Platform)
 	}
 
 	if err := c.parseNodeMatcher(); err != nil {
@@ -218,9 +226,8 @@ func printOutResponse(response *csdspb_v3.ClientStatusResponse, opts client.Clie
 	if response.GetConfig() == nil || len(response.GetConfig()) == 0 {
 		fmt.Printf("No xDS clients connected.\n")
 		return nil
-	} else {
-		fmt.Printf("%-50s %-30s %-30s \n", "Client ID", "xDS stream type", "Config Status")
 	}
+	fmt.Printf("%-50s %-30s %-30s \n", "Client ID", "xDS stream type", "Config Status")
 
 	var hasXdsConfig bool
 

--- a/csds-client/main.go
+++ b/csds-client/main.go
@@ -5,12 +5,14 @@ import (
 	client_v2 "envoy-tools/csds-client/client/v2"
 	client_v3 "envoy-tools/csds-client/client/v3"
 	"flag"
+	"fmt"
 	"log"
 	"time"
 )
 
 // flag vars
 var uri string
+var authority string
 var platform string
 var authnMode string
 var apiVersion string
@@ -22,10 +24,14 @@ var monitorInterval time.Duration
 var visualization bool
 var filterMode string
 var filterPattern string
+var tlsCertFilepath string
+var tlsCACertsFilepath string
+var tlsPrivateKeyFilepath string
 
 // const default values for flag vars
 const (
 	uriDefault             string        = "trafficdirector.googleapis.com:443"
+	authorityDefault       string        = ""
 	platformDefault        string        = "gcp"
 	authnModeDefault       string        = "auto"
 	apiVersionDefault      string        = "v2"
@@ -37,12 +43,16 @@ const (
 	visualizationDefault   bool          = false
 	filterModeDefault      string        = ""
 	filterPatternDefault   string        = ""
+	TLSCertFilepath        string        = ""
+	TLSPrivateKeyFilepath  string        = ""
+	TLSCACertsFilepath     string        = ""
 )
 
 // init binds flags with variables
 func init() {
 	flag.StringVar(&uri, "service_uri", uriDefault, "the uri of the service to connect to")
-	flag.StringVar(&platform, "platform", platformDefault, "the platform (e.g. gcp, aws,  ...)")
+	flag.StringVar(&authority, "authority", authorityDefault, "the :authority header to use when connecting to uri")
+	flag.StringVar(&platform, "platform", platformDefault, fmt.Sprintf("the target platform, one of %v", client.SupportedPlatforms))
 	flag.StringVar(&authnMode, "authn_mode", authnModeDefault, "the method to use for authentication (e.g. auto, jwt, ...)")
 	flag.StringVar(&apiVersion, "api_version", apiVersionDefault, "which xds api major version to use (e.g. v2, v3, ...)")
 	flag.StringVar(&requestFile, "request_file", requestFileDefault, "yaml file that defines the csds request")
@@ -53,23 +63,30 @@ func init() {
 	flag.BoolVar(&visualization, "visualization", visualizationDefault, "option to visualize the relationship between xDS")
 	flag.StringVar(&filterMode, "filter_mode", filterModeDefault, "the filter mode for the filter on xDS nodes to be returned (e.g. prefix, suffix, regex, ...)")
 	flag.StringVar(&filterPattern, "filter_pattern", filterPatternDefault, "the filter pattern for the filter on xDS nodes to be returned")
+	flag.StringVar(&tlsCertFilepath, "cert", tlsCertFilepath, "filepath to the client TLS certificate")
+	flag.StringVar(&tlsPrivateKeyFilepath, "key", tlsPrivateKeyFilepath, "filepath to the client TLS private key")
+	flag.StringVar(&tlsCACertsFilepath, "cacert", tlsCACertsFilepath, "filepath to the CAs certs used to verify the server's certificate")
 }
 
 func main() {
 	flag.Parse()
 
 	clientOpts := client.ClientOptions{
-		Uri:             uri,
-		Platform:        platform,
-		AuthnMode:       authnMode,
-		RequestFile:     requestFile,
-		RequestYaml:     requestYaml,
-		Jwt:             jwt,
-		ConfigFile:      configFile,
-		MonitorInterval: monitorInterval,
-		Visualization:   visualization,
-		FilterMode:      filterMode,
-		FilterPattern:   filterPattern,
+		Uri:                   uri,
+		Authority:             authority,
+		Platform:              platform,
+		AuthnMode:             authnMode,
+		RequestFile:           requestFile,
+		RequestYaml:           requestYaml,
+		Jwt:                   jwt,
+		ConfigFile:            configFile,
+		MonitorInterval:       monitorInterval,
+		Visualization:         visualization,
+		FilterMode:            filterMode,
+		FilterPattern:         filterPattern,
+		TLSCertFilepath:       tlsCertFilepath,
+		TLSCACertsFilepath:    tlsCACertsFilepath,
+		TLSPrivateKeyFilepath: tlsPrivateKeyFilepath,
 	}
 
 	var c client.Client


### PR DESCRIPTION
👋 This proposal adds support for OSS implementations of the xDS control plane.


Kindly let me know whether this is something you would like integrated into envoy-tools/csds-client, and what are your thoughts on this approach.


## platform `go`

This patch adds support for a second type of platform, named `go`. It does so by providing utility function `ConnToXDS` and `DialOptions` to initiate gRPCs to the address specified by the flag `service_uri`.

### authentication options for platform `go`

Support is added for mTLS via the introduction of the following new flags:
```
  -authority string
        the :authority header to use when connecting to uri
  -cacert string
        filepath to the CAs certs used to verify the server's certificate
  -cert string
        filepath to the client TLS certificate
  -key string
        filepath to the client TLS private key
```

The the client certificate/private key pair are included in the ClientHello message for establishing a connection over TLS.

If a certificate authority is provided via `cacert`, it is used to validate the server's certificate identity.

Additionally, the `-authority` flag allows for setting the HTTP/2 `:authority` header to use for SNI.

## Example

```shell
$ ~/github/owayss/envoy-tools/csds-client/csds-client \
    -request_file ~/github/owayss/envoy-tools/csds-client/client/v3/test_request.yaml \
    -cert client.crt \
    -key client.key \
    -cacert ca.crt \
    -service_uri localhost:18000 \
    -platform go \
    -api_version v3 
```
<details>
  <summary>Click to expand response output</summary>

```
Client ID                                          xDS stream type                Config Status                  
api-gateway                                                                       CDS   SYNCED                   
                                                                                  LDS   SYNCED                   
Detailed Config:
{
  "config": [
    {
      "node": {
        "id": "api-gateway"
      },
      "xdsConfig": [
        {
          "status": "SYNCED",
          "clusterConfig": {
            "staticClusters": [
              {
                "cluster": {
                  "@type": "type.googleapis.com/envoy.config.cluster.v3.Cluster",
                  "name": "service_api-gateway-stg",
                  "type": "STRICT_DNS",
                  "connectTimeout": "5s",
                  "loadAssignment": {
                    "clusterName": "service_api-gateway-stg",
                    "endpoints": [
                      {
                        "lbEndpoints": [
                          {},
                          {
                            "endpoint": {
                              "address": {
                                "socketAddress": {
                                  "address": "envoyproxy.io",
                                  "portValue": 443
                                }
                              }
                            }
                          }
                        ]
                      }
                    ]
                  },
                  "healthChecks": [
                    {
                      "timeout": "5s",
                      "interval": "5s",
                      "unhealthyThreshold": 3,
                      "healthyThreshold": 3,
                      "reuseConnection": true,
                      "httpHealthCheck": {
                        "host": "api-gateway-stg.mydomain.com",
                        "path": "/api/health",
                        "expectedStatuses": [
                          {
                            "start": "200",
                            "end": "405"
                          }
                        ]
                      },
                      "noTrafficInterval": "60s",
                      "eventLogPath": "/dev/stdout",
                      "alwaysLogHealthCheckFailures": true
                    }
                  ],
                  "dnsLookupFamily": "V4_ONLY",
                  "transportSocket": {
                    "name": "envoy.transport_sockets.tls"
                  }
                }
              }
            ]
          }
        },
        {
          "status": "SYNCED",
          "listenerConfig": {
            "staticListeners": [
              {
                "listener": {
                  "@type": "type.googleapis.com/envoy.config.listener.v3.Listener",
                  "name": "listener_api-gateway-stg",
                  "address": {
                    "socketAddress": {
                      "address": "0.0.0.0",
                      "portValue": 4455
                    }
                  },
                  "filterChains": [
                    {
                      "filters": [
                        {
                          "name": "envoy.filters.network.http_connection_manager",
                          "typedConfig": {
                            "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
                            "statPrefix": "http",
                            "routeConfig": {
                              "name": "route_api-gateway-stg",
                              "virtualHosts": [
                                {
                                  "name": "route_api-gateway-stg",
                                  "domains": [
                                    "*"
                                  ],
                                  "routes": [
                                    {
                                      "match": {
                                        "path": "/__envoy__/status"
                                      },
                                      "directResponse": {
                                        "status": 200,
                                        "body": {
                                          "inlineString": "OK"
                                        }
                                      }
                                    },
                                    {
                                      "match": {
                                        "prefix": "/"
                                      },
                                      "route": {
                                        "cluster": "service_api-gateway-stg",
                                        "hostRewriteLiteral": "api-gateway-stg.mydomain.com"
                                      }
                                    }
                                  ]
                                }
                              ]
                            },
                            "httpFilters": [
                              {
                                "name": "envoy.filters.http.router"
                              }
                            ],
                            "accessLog": [
                              {
                                "name": "envoy.access_loggers.file",
                                "typedConfig": {
                                  "@type": "type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog",
                                  "path": "/dev/stdout",
                                  "logFormat": {
                                    "jsonFormat": {
                                      "bytes_received": "%BYTES_RECEIVED%",
                                      "bytes_sent": "%BYTES_SENT%",
                                      "downstream_local_address": "%DOWNSTREAM_LOCAL_ADDRESS%",
                                      "downstream_local_uri_san": "%DOWNSTREAM_LOCAL_URI_SAN%",
                                      "downstream_peer_uri_san": "%DOWNSTREAM_PEER_URI_SAN%",
                                      "downstream_remote_address": "%DOWNSTREAM_REMOTE_ADDRESS%",
                                      "duration": "%DURATION%",
                                      "envoy_upstream_service_time": "%RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)%",
                                      "epoch_micro": "%START_TIME(%s.%6f)%",
                                      "jwt_aud": "%DYNAMIC_METADATA(envoy.filters.http.jwt_authn\\:config)%",
                                      "protocol": "%PROTOCOL%",
                                      "req_authority": "%REQ(:AUTHORITY)%",
                                      "req_envoy_original_path": "%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%",
                                      "req_path": "%REQ(:PATH)%",
                                      "req_user_agent": "%REQ(USER-AGENT)%",
                                      "req_x_request_id": "%REQ(X-REQUEST-ID)%",
                                      "req_xff": "%REQ(X-FORWARDED-FOR)%",
                                      "request_method": "%REQ(:METHOD)%",
                                      "response_code": "%RESPONSE_CODE%",
                                      "response_duration": "%RESPONSE_DURATION%",
                                      "response_flags": "%RESPONSE_FLAGS%",
                                      "response_tx_duration": "%RESPONSE_TX_DURATION%",
                                      "start_time": "%START_TIME(%Y/%m/%d %H:%M:%S)%",
                                      "upstream_cluster": "%UPSTREAM_CLUSTER%",
                                      "upstream_host": "%UPSTREAM_HOST%",
                                      "upstream_local_address": "%UPSTREAM_LOCAL_ADDRESS%",
                                      "upstream_transport_failure_reason": "%UPSTREAM_TRANSPORT_FAILURE_REASON%"
                                    }
                                  }
                                }
                              }
                            ]
                          }
                        }
                      ]
                    }
                  ]
                }
              }
            ]
          }
        }
      ]
    }
  ]
}

```
</details>


### 

### Testing coverage

The patch does not include any additional tests. The various test functions in the `client/v2` and `client/v3` seem to cover the existing utility functions (for parsing and printing out detailed responses) with golden JSON data files.

The part that I think would benefit from a unit test is the `DialOptions` functions that configures the HTTP/2 connection depending on the provided command-line flags for authentication.

---


Best,
Owayss.