### PR TITLE
Read config dumps from generic_xds_configs instead of deprecated xds_…

### DIFF
--- a/csds-client/client/v3/client.go
+++ b/csds-client/client/v3/client.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	csdspb_v3 "github.com/envoyproxy/go-control-plane/envoy/service/status/v3"
 	envoy_type_matcher_v3 "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
 	"google.golang.org/grpc"
@@ -26,6 +27,7 @@ type ClientV3 struct {
 	csdsClient csdspb_v3.ClientStatusDiscoveryServiceClient
 
 	nodeMatcher []*envoy_type_matcher_v3.NodeMatcher
+	node envoy_config_core_v3.Node
 	metadata    metadata.MD
 	opts        client.ClientOptions
 }
@@ -46,11 +48,13 @@ func (c *ClientV3) parseNodeMatcher() error {
 	}
 
 	var nodematchers []*envoy_type_matcher_v3.NodeMatcher
-	if err := parseYaml(c.opts.RequestFile, c.opts.RequestYaml, &nodematchers); err != nil {
+	var node envoy_config_core_v3.Node
+	if err := parseYaml(c.opts.RequestFile, c.opts.RequestYaml, &nodematchers, &node); err != nil {
 		return err
 	}
 
 	c.nodeMatcher = nodematchers
+	c.node = node
 
 	// check if required fields exist in NodeMatcher
 	switch c.opts.Platform {
@@ -180,7 +184,7 @@ func (c *ClientV3) Run() error {
 // doRequest sends request and prints out the parsed response
 func (c *ClientV3) doRequest(streamClientStatus csdspb_v3.ClientStatusDiscoveryService_StreamClientStatusClient) error {
 
-	req := &csdspb_v3.ClientStatusRequest{NodeMatchers: c.nodeMatcher}
+	req := &csdspb_v3.ClientStatusRequest{NodeMatchers: c.nodeMatcher, Node: &envoy_config_core_v3.Node{Id: c.node.Id}}
 	if err := streamClientStatus.Send(req); err != nil {
 		return err
 	}
@@ -198,20 +202,21 @@ func (c *ClientV3) doRequest(streamClientStatus csdspb_v3.ClientStatusDiscoveryS
 }
 
 // parseConfigStatus parses each xds config status to string
-func parseConfigStatus(xdsConfig []*csdspb_v3.PerXdsConfig) []string {
+func parseConfigStatus(xdsConfig []*csdspb_v3.ClientConfig_GenericXdsConfig) []string {
 	var configStatus []string
-	for _, perXdsConfig := range xdsConfig {
-		status := perXdsConfig.GetStatus().String()
+	for _, genericXdsConfig := range xdsConfig {
+		status := genericXdsConfig.GetConfigStatus().String()
 		var xds string
-		if perXdsConfig.GetClusterConfig() != nil {
+		switch genericXdsConfig.GetTypeUrl() {
+		case "type.googleapis.com/envoy.config.cluster.v3.Cluster":
 			xds = "CDS"
-		} else if perXdsConfig.GetListenerConfig() != nil {
+		case "type.googleapis.com/envoy.config.listener.v3.Listener":
 			xds = "LDS"
-		} else if perXdsConfig.GetRouteConfig() != nil {
+		case "type.googleapis.com/envoy.config.route.v3.RouteConfiguration":
 			xds = "RDS"
-		} else if perXdsConfig.GetScopedRouteConfig() != nil {
+		case "type.googleapis.com/envoy.config.route.v3.ScopedRouteConfiguration":
 			xds = "SRDS"
-		} else if perXdsConfig.GetEndpointConfig() != nil {
+		case "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment":
 			xds = "EDS"
 		}
 		if status != "" && xds != "" {
@@ -257,7 +262,7 @@ func printOutResponse(response *csdspb_v3.ClientStatusResponse, opts client.Clie
 			}
 		}
 
-		if config.GetXdsConfig() == nil {
+		if config.GetGenericXdsConfigs() == nil {
 			if config.GetNode() != nil {
 				fmt.Printf("%-50s %-30s %-30s \n", id, xdsType, "N/A")
 			}
@@ -265,7 +270,7 @@ func printOutResponse(response *csdspb_v3.ClientStatusResponse, opts client.Clie
 			hasXdsConfig = true
 
 			// parse config status
-			configStatus := parseConfigStatus(config.GetXdsConfig())
+			configStatus := parseConfigStatus(config.GetGenericXdsConfigs())
 			fmt.Printf("%-50s %-30s ", id, xdsType)
 
 			for i := 0; i < len(configStatus); i++ {
@@ -290,7 +295,7 @@ func printOutResponse(response *csdspb_v3.ClientStatusResponse, opts client.Clie
 }
 
 // parseYaml is a helper method for parsing csds request yaml to NodeMatchers
-func parseYaml(path string, yamlStr string, nms *[]*envoy_type_matcher_v3.NodeMatcher) error {
+func parseYaml(path string, yamlStr string, nms *[]*envoy_type_matcher_v3.NodeMatcher, node *envoy_config_core_v3.Node) error {
 	if path != "" {
 		data, err := clientutil.ParseYamlFileToMap(path)
 		if err != nil {
@@ -309,6 +314,19 @@ func parseYaml(path string, yamlStr string, nms *[]*envoy_type_matcher_v3.NodeMa
 				return err
 			}
 			*nms = append(*nms, x)
+		}
+
+		// Extract the node id from the request YAML
+		n := &envoy_config_core_v3.Node{}
+		if nv, ok := data["node"]; ok {
+			jsonString, err := json.Marshal(nv)
+			if err != nil {
+				return err
+			}
+			if err = protojson.Unmarshal(jsonString, n); err != nil {
+				return err
+			}
+			*node = *n
 		}
 	}
 	if yamlStr != "" {

--- a/csds-client/client/v3/client_test.go
+++ b/csds-client/client/v3/client_test.go
@@ -35,6 +35,15 @@ func TestParseNodeMatcherWithFile(t *testing.T) {
 	if !clientUtil.ShouldEqualJSON(t, string(get), want) {
 		t.Errorf("NodeMatcher = \n%v\n, want: \n%v\n", string(get), want)
 	}
+	wantNode := "{\"id\":\"fake_client_node_id\"}"
+	getNode, errNode := protojson.Marshal(&c.node)
+	if err != nil {
+		t.Errorf("Parse NodeMatcher Error: %v", errNode)
+	}
+
+	if !clientUtil.ShouldEqualJSON(t, string(getNode), wantNode) {
+		t.Errorf("NodeMatcher = \n%v\n, want: \n%v\n", string(getNode), wantNode)
+	}
 }
 
 // TestParseNodeMatcherWithString tests parsing -request_yaml to nodematcher.

--- a/csds-client/client/v3/client_test.go
+++ b/csds-client/client/v3/client_test.go
@@ -38,7 +38,7 @@ func TestParseNodeMatcherWithFile(t *testing.T) {
 	wantNode := "{\"id\":\"fake_client_node_id\"}"
 	getNode, errNode := protojson.Marshal(&c.node)
 	if err != nil {
-		t.Errorf("Parse NodeMatcher Error: %v", errNode)
+		t.Errorf("Parse Node Error: %v", errNode)
 	}
 
 	if !clientUtil.ShouldEqualJSON(t, string(getNode), wantNode) {

--- a/csds-client/client/v3/response_with_nodeid_test.json
+++ b/csds-client/client/v3/response_with_nodeid_test.json
@@ -9,32 +9,29 @@
           "XDS_STREAM_TYPE": "test_stream_type1"
         }
       },
-      "xdsConfig": [
+      "genericXdsConfigs": [
         {
-          "status": "STALE",
-          "routeConfig": {
-            "dynamicRouteConfigs": [
-              {
-                "versionInfo": "fake_route_version1"
-              },
-              {
-                "versionInfo": "fake_route_version2"
-              }
-            ]
-          }
+          "typeUrl":  "type.googleapis.com/envoy.config.route.v3.RouteConfiguration",
+          "name":  "fake_route",
+          "versionInfo":  "fake_route_version1",
+          "xdsConfig":  {
+            "@type":  "type.googleapis.com/envoy.config.route.v3.RouteConfiguration",
+            "name":  "fake_route"
+          },
+          "configStatus":  "STALE"
         },
         {
-          "status": "STALE",
-          "clusterConfig": {
-            "dynamicActiveClusters": [
-              {
-                "versionInfo": "fake_cluster_version1"
-              },
-              {
-                "versionInfo": "fake_cluster_version2"
-              }
-            ]
-          }
+          "typeUrl":  "type.googleapis.com/envoy.config.cluster.v3.Cluster",
+          "name":  "fake_cluster",
+          "versionInfo":  "fake_cluster_version1",
+          "xdsConfig":  {
+            "@type":  "type.googleapis.com/envoy.config.cluster.v3.Cluster",
+            "name":  "fake_cluster",
+            "type":  "ORIGINAL_DST",
+            "connectTimeout":  "5s",
+            "lbPolicy":  "CLUSTER_PROVIDED"
+          },
+          "configStatus":  "STALE"
         }
       ]
     }

--- a/csds-client/client/v3/test_request.yaml
+++ b/csds-client/client/v3/test_request.yaml
@@ -1,3 +1,5 @@
+node:
+  id: fake_client_node_id
 node_matchers:
   - node_id:
       exact: fake_node_id


### PR DESCRIPTION
The following updates to accommodate changes in CSDS v3 specification.
- As per CSDS v3 specification in https://github.com/envoyproxy/envoy/blob/main/api/envoy/service/status/v3/csds.proto the CSDS response will capture config dump in generic_xds_configs (GenericXdsConfig type) field instead of the deprecated xds_config (PerXdsConfig type) field.
- CSDS v3 request has additional field 'node' to identify the node making the request.